### PR TITLE
preserve chronologically order of time slots

### DIFF
--- a/src/Resources/public/src/js/c4g_brick_reservation.js
+++ b/src/Resources/public/src/js/c4g_brick_reservation.js
@@ -561,7 +561,16 @@ function addRadioFieldSet(radioGroup, data, additionalId, capacity, showDateTime
     }
 
     //add new childs to radioGroup
-    for (let key in times) {
+    Object.keys(times)
+    .sort((a, b) => {
+        // Split the keys by '#'
+        let timeA = a.split('#')[0];
+        let timeB = b.split('#')[0];
+
+        // Compare the beginning time to determine the order
+        return timeA - timeB;
+    })
+    .forEach(function(key) {
         var name = times[key]['name'];
         var interval = times[key]['interval'];
         var time = times[key]['time'];
@@ -663,7 +672,7 @@ function addRadioFieldSet(radioGroup, data, additionalId, capacity, showDateTime
         radioGroup.appendChild(c4gFormCheck);
 
         radioGroup.parentNode.parentNode.getElementsByClassName('c4g__form-description')[0].innerText = description;
-    }
+    });
 
     //return objstr;
 }


### PR DESCRIPTION
Sometimes booked time slots are shown before available time slots instead of preserving a chronologically order. In my case when hiding end times.

![image](https://github.com/Kuestenschmiede/ReservationBundle/assets/6286711/398d4a9a-b62f-4e4b-94a7-f72908137093)
![image](https://github.com/Kuestenschmiede/ReservationBundle/assets/6286711/8f42ef2a-aaea-45e7-8933-d1b2929f2d21)

This patch preserves the correct order:

![image](https://github.com/Kuestenschmiede/ReservationBundle/assets/6286711/0cfc478e-0ce9-4762-869b-d887a21fb081)

