### PR TITLE
Increase `tl_c4g_reservation_event_participants.booker` length

### DIFF
--- a/src/Resources/contao/dca/tl_c4g_reservation_event_participants.php
+++ b/src/Resources/contao/dca/tl_c4g_reservation_event_participants.php
@@ -271,7 +271,7 @@ $GLOBALS['TL_DCA']['tl_c4g_reservation_event_participants'] = array
             'inputType'               => 'text',
             'eval'                    => array(
                                             'mandatory'=>false, 'maxlength'=>254, 'feEditable'=>true, 'feViewable'=>true, 'feGroup'=>'personal', 'tl_class'=>'clr'),
-            'sql'                     => "varchar(50) NOT NULL default ''"
+            'sql'                     => array('type' => 'string', 'length' => 254, 'default' => ''),
         ),
 
         'additional1' => array (


### PR DESCRIPTION
The `eval.maxlength` value and the value used for the length of the database field to do not match for `tl_c4g_reservation_event_participants.booker`. This PR fixes that by increasing the database length to the `eval.maxlength` value.